### PR TITLE
[codex] fix llama-swap v204 build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,7 +35,7 @@ RUN cmake -S . -B build -G Ninja \
 	  -DLLAMA_LLGUIDANCE=ON
 RUN cmake --build build --target llama-server -j"$(nproc)"
 
-FROM golang:bookworm AS llama-swap-build
+FROM golang:trixie AS llama-swap-build
 
 # renovate: datasource=github-releases depName=mostlygeek/llama-swap versioning=regex:^v(?<major>\d+)$
 ARG LLAMA_SWAP_REF=v195


### PR DESCRIPTION
## What changed
- Switched the `llama-swap-build` stage to `golang:trixie` so the bundled Debian `nodejs` meets the `llama-swap v204` frontend build requirement.

## Why
- `llama-swap v204` uses Vite 8, which requires Node.js 20.19+.
- The previous `golang:bookworm` stage installed Node.js 18.20.4, causing `make clean all` to fail during the UI build.

## Validation
- `docker build --target llama-swap-build --build-arg LLAMA_SWAP_REF=v204 -f Dockerfile .`
- `docker build --build-arg LLAMA_SWAP_REF=v204 -f Dockerfile .`