### PR TITLE
[codex] Add llama.cpp image tag

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -59,6 +59,17 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Read llama.cpp ref
+        id: llama_cpp
+        run: |
+          set -eu
+          llama_cpp_ref="$(sed -n 's/^ARG LLAMA_CPP_REF=//p' Dockerfile)"
+          if [ -z "${llama_cpp_ref}" ]; then
+            echo "LLAMA_CPP_REF is not set in Dockerfile" >&2
+            exit 1
+          fi
+          echo "ref=${llama_cpp_ref}" >> "${GITHUB_OUTPUT}"
+
       - name: Extract metadata
         id: meta
         uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9 # v6.1.0
@@ -66,6 +77,7 @@ jobs:
           images: ghcr.io/tosuke/images/llama-server
           tags: |
             type=raw,value=latest
+            type=raw,value=${{ steps.llama_cpp.outputs.ref }}
             type=sha,format=short
 
       - name: Set up Buildx


### PR DESCRIPTION
## Summary
Add the `LLAMA_CPP_REF` value from `Dockerfile` as a Docker image tag in the build workflow.

## Why
The image is currently tagged only with `latest` and the commit SHA, which makes it harder to pull an image that matches the bundled `llama.cpp` release.

## Impact
Images published from `main` will also be tagged with the current `llama.cpp` ref, such as `b9326`.

## Validation
- Verified locally that `sed -n 's/^ARG LLAMA_CPP_REF=//p' Dockerfile` returns `b9326` on `main`.
- Confirmed the workflow diff adds that value to `docker/metadata-action` tags while keeping the existing `latest` and SHA tags.
