### PR TITLE
[codex] Cap Valkey cache snapshot size to 256MB

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,6 +11,10 @@ permissions:
   contents: read
   packages: write
 
+env:
+  VALKEY_MAXMEMORY: 256mb
+  VALKEY_MAXMEMORY_POLICY: allkeys-lfu
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -48,6 +52,8 @@ jobs:
             valkey-server \
               --dir /data \
               --dbfilename dump.rdb \
+              --maxmemory "${VALKEY_MAXMEMORY}" \
+              --maxmemory-policy "${VALKEY_MAXMEMORY_POLICY}" \
               --save 60 1 \
               --protected-mode no)
           echo "endpoint=$(docker inspect -f 'redis://{{.NetworkSettings.IPAddress}}:6379' "$id")" >> "${GITHUB_OUTPUT}"
@@ -101,6 +107,7 @@ jobs:
         run: |
           set -eux
           if docker ps -a --format '{{.Names}}' | grep -Fx valkey >/dev/null; then
+            docker exec valkey valkey-cli -h 127.0.0.1 info memory || true
             docker exec valkey valkey-cli -h 127.0.0.1 save || true
             docker stop valkey || true
             docker rm valkey || true


### PR DESCRIPTION
## Summary
- cap the persisted Valkey cache to 256MB in the build workflow
- let Valkey evict colder entries with `allkeys-lfu` before the snapshot is saved
- log memory info before `SAVE` so the retained cache size is visible in workflow output

## Why
The Valkey snapshot is stored in GitHub Actions cache, so a large in-memory cache turns into a large `dump.rdb`. This keeps the persisted cache smaller while still retaining hot `sccache` entries.

## Validation
- checked the workflow diff locally
- validated YAML syntax with `yq '.' .github/workflows/build.yml`
